### PR TITLE
add pthread to link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,9 @@ set(SOURCE_FILES src/app/Application.cpp src/app/Application.hpp
     src/event/irc/EventIrcReconnectServer.cpp src/event/irc/EventIrcReconnectServer.hpp
     src/event/EventQuit.cpp src/event/EventQuit.hpp)
 
-set(LINK_LIBRARIES "")
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+set(LINK_LIBRARIES "Threads::Threads")
 set(INCLUDE_DIRECTORIES "")
 
 


### PR DESCRIPTION
Hello :smile:!

I'm interested in fixing your **Hacktoberfest** issues (maybe I'll find some time for more), but I wasn't able to build Harpoon with cmake **v3.5.1**, so...

I'd like to propose this fix :hammer:. Without these three lines, after running `make` I got:

```
/usr/bin/ld: CMakeFiles/iirc.dir/src/queue/EventLoop.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
CMakeFiles/iirc.dir/build.make:2103: recipe for target 'iirc' failed
make[2]: *** [iirc] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/iirc.dir/all' failed
make[1]: *** [CMakeFiles/iirc.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```

I hope it will work also for you.
