### PR TITLE
fix copy-paste bug with enableIrcBacklog option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,9 +85,9 @@ void doSetup(bool save) {
         } while (find(validIrcDatabaseTypes.begin(), validIrcDatabaseTypes.end(), ircSettingsDatabaseType) == validIrcDatabaseTypes.end());
         do {
             cout << "Collect IRC backlog (y/n) [y]: ";
-            getline(cin, ircSettingsDatabaseType);
-            if (ircSettingsDatabaseType.size() == 0) // auto value
-                ircSettingsDatabaseType = "y";
+            getline(cin, enableIrcBacklog);
+            if (enableIrcBacklog.size() == 0) // auto value
+                enableIrcBacklog = "y";
         } while (find(validYesNoAnswers.begin(), validYesNoAnswers.end(), enableIrcBacklog) == validYesNoAnswers.end());
     }
 


### PR DESCRIPTION
It seems that you've copied previous `do-while` and didn't change option name to `enableIrcBacklog` in its body. Because of that, on running Harpoon with `--setup` option (without previously set config in `config` dir) user got infinite series of irc backlog prompts.
