### PR TITLE
Add Dockerfile for compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.10
+MAINTAINER Łukasz Hryniuk "lukasz.hryniuk@wp.pl"
+
+RUN apt update && \
+    apt install -y \
+        cmake \
+        gcc \
+        g++ \
+        libircclient-dev \
+        libjsoncpp-dev \
+        libsoci-dev \
+        libssl-dev \
+        python \
+        wget
+
+RUN wget https://github.com/mattgodbolt/seasocks/archive/v1.2.4.tar.gz && \
+    tar xvfz v1.2.4.tar.gz && \
+    cd seasocks-1.2.4 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install && \
+    make clean
+
+VOLUME ["/harpoon"]


### PR DESCRIPTION
PR connected to #6.

This Dockerfile uses [the newest release of Seasocks from GitHub](https://github.com/mattgodbolt/seasocks/releases), cause I didn't find any `*seasocks*` package in the Ubuntu repository.

I've pushed a Docker image based on this Dockerfile to hub: https://hub.docker.com/r/lukequaint/harpoon/.

Check it twice :smile:.

I think it would be better if you push the image to the Docker :whale: Hub under **your** namespace. Let me know if you do this, so I will be able to put proper link to the **README.md**.
